### PR TITLE
feat(qdrant): Integrate PubMedQA dataset with context-only optimization

### DIFF
--- a/scripts/02_rag_query.bat
+++ b/scripts/02_rag_query.bat
@@ -4,7 +4,7 @@ REM RAG system for MedMax
 
 echo Starting MedMax RAG System...
 echo.
-echo Collection: medmax_pubmed
+echo Collection: medmax_pubmed_full
 echo.
 echo Choose mode:
 echo [1] Interactive session (recommended)
@@ -22,23 +22,23 @@ goto invalid_choice
 
 :interactive
 echo Starting interactive RAG session...
-cmd /c "micromamba activate medproj && python -m src.rag.main interactive"
+cmd /c "micromamba activate medproj && python -m src.rag.main interactive --collection-name medmax_pubmed_full"
 goto end
 
 :single_query
 set /p question="Enter your medical question: "
 echo Running single query...
-cmd /c "micromamba activate medproj && python -m src.rag.main query ^"!question!^""
+cmd /c "micromamba activate medproj && python -m src.rag.main query ^"!question!^" --collection-name medmax_pubmed_full"
 goto end
 
 :test_questions
 echo Testing with sample medical questions...
 echo.
 echo Question 1: What is diabetes?
-cmd /c "micromamba activate medproj && python -m src.rag.main query ^"What is diabetes?^""
+cmd /c "micromamba activate medproj && python -m src.rag.main query ^"What is diabetes?^" --collection-name medmax_pubmed_full"
 echo.
 echo Question 2: Treatment options for hypertension?
-cmd /c "micromamba activate medproj && python -m src.rag.main query ^"What are the treatment options for hypertension?^""
+cmd /c "micromamba activate medproj && python -m src.rag.main query ^"What are the treatment options for hypertension?^" --collection-name medmax_pubmed_full"
 goto end
 
 :advanced_query
@@ -49,12 +49,12 @@ set /p model="OpenAI model (default gpt-4o-mini): "
 if "!model!"=="" set model=gpt-4o-mini
 
 echo Running advanced query...
-cmd /c "micromamba activate medproj && python -m src.rag.main query ^"!question!^" --top-k !top_k! --model !model! --engine-type enhanced --verbose"
+cmd /c "micromamba activate medproj && python -m src.rag.main query ^"!question!^" --top-k !top_k! --model !model! --engine-type enhanced --verbose --collection-name medmax_pubmed_full"
 goto end
 
 :invalid_choice
 echo Invalid choice. Starting interactive session...
-cmd /c "micromamba activate medproj && python -m src.rag.main interactive"
+cmd /c "micromamba activate medproj && python -m src.rag.main interactive --collection-name medmax_pubmed_full"
 
 :end
 if %errorlevel% neq 0 (

--- a/src/rag/main.py
+++ b/src/rag/main.py
@@ -313,8 +313,8 @@ Examples:
     
     parser.add_argument(
         "--collection-name",
-        default="medmax_pubmed",
-        help="Qdrant collection name to query (default: medmax_pubmed)"
+        default="medmax_pubmed_full",
+        help="Qdrant collection name to query (default: medmax_pubmed_full)"
     )
     
     parser.add_argument(
@@ -343,6 +343,13 @@ Examples:
         help="Show detailed source information"
     )
     
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.3,
+        help="Similarity score threshold for retrieval (default: 0.3)"
+    )
+    
     args = parser.parse_args(argv)
     
 
@@ -355,7 +362,7 @@ Examples:
 
         if args.mode == "rag":
             configure_global_settings()
-            vector_store, index = setup_rag_client(args.collection_name)
+            _, index = setup_rag_client(args.collection_name)
             if args.engine_type == "simple":
                 query_engine = create_simple_query_engine(index, top_k=args.top_k)
             elif args.engine_type == "enhanced":
@@ -364,6 +371,7 @@ Examples:
                     collection_name=args.collection_name,
                     top_k=args.top_k, 
                     llm_model=args.model,
+                    score_threshold=args.threshold,
                     verbose=args.verbose
                 )
             else:
@@ -371,7 +379,8 @@ Examples:
                     index,
                     collection_name=args.collection_name,
                     top_k=args.top_k,
-                    llm_model=args.model
+                    llm_model=args.model,
+                    score_threshold=args.threshold
                 )
             query_engine = patch_query_engine_with_tracing(query_engine)
             print("RAG system ready!")

--- a/src/vector_store/loader.py
+++ b/src/vector_store/loader.py
@@ -1,9 +1,102 @@
-"""Data loading and formatting for PubMed data."""
-
 import json
-from typing import List, Dict, Any
+import pandas as pd
+from typing import List, Dict, Any, Optional, Tuple
 from pathlib import Path
 from tqdm import tqdm
+
+
+def load_pubmedqa_parquet_data(
+    data_dir: str = "data",
+    limit_per_dataset: Optional[int] = None
+) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
+    """Load PubMedQA data from parquet files with deduplication.
+    
+    Args:
+        data_dir: Directory containing the parquet files
+        limit_per_dataset: Optional limit for number of records per dataset
+        
+    Returns:
+        Tuple of (unique_records, statistics)
+    """
+    print("Loading PubMedQA datasets from parquet files...")
+    
+    data_path = Path(data_dir)
+    unlabeled_path = data_path / "pqa_unlabeled_train.parquet"
+    labeled_path = data_path / "pqa_labeled_train.parquet"
+    artificial_path = data_path / "pqa_artificial_train.parquet"
+    
+    missing_files = []
+    for path in [unlabeled_path, labeled_path, artificial_path]:
+        if not path.exists():
+            missing_files.append(str(path))
+    
+    if missing_files:
+        print(f"Missing parquet files: {missing_files}")
+        return [], {"error": "missing_files"}
+    
+
+    df_unlabeled = pd.read_parquet(unlabeled_path)
+    df_labeled = pd.read_parquet(labeled_path)
+    df_artificial = pd.read_parquet(artificial_path)
+    
+    print("Dataset sizes:")
+    print(f"  - Unlabeled: {len(df_unlabeled)} records")
+    print(f"  - Labeled: {len(df_labeled)} records") 
+    print(f"  - Artificial: {len(df_artificial)} records")
+    
+    if limit_per_dataset:
+        print(f"Applying limit of {limit_per_dataset} records per dataset")
+        df_unlabeled = df_unlabeled.head(limit_per_dataset)
+        df_labeled = df_labeled.head(limit_per_dataset)
+        df_artificial = df_artificial.head(limit_per_dataset)
+    
+    unique_records = {}
+    stats = {"unlabeled": 0, "labeled": 0, "artificial": 0, "duplicates": 0}
+    
+    def process_dataset(df: pd.DataFrame, dataset_name: str, has_final_decision: bool = False):
+        """Process a single dataset and extract unique records."""
+        dataset_stats = 0
+        
+        for idx, row in tqdm(df.iterrows(), desc=f"Processing {dataset_name}", total=len(df)):
+            pubid = row['pubid']
+            
+            # Skip if we already have this pubid (deduplication)
+            if pubid in unique_records:
+                stats["duplicates"] += 1
+                continue
+            
+            contexts_list = row['context']['contexts'].tolist()
+            
+            record_data = {
+                'question': row['question'],
+                'contexts': contexts_list,
+                'long_answer': row['long_answer'],
+                'pubid': pubid,
+                'dataset_source': dataset_name
+            }
+            
+            if has_final_decision and 'final_decision' in row:
+                record_data['final_decision'] = row['final_decision']
+            
+            unique_records[pubid] = record_data
+            dataset_stats += 1
+        
+        return dataset_stats
+    
+    stats["unlabeled"] = process_dataset(df_unlabeled, "unlabeled", False)
+    stats["labeled"] = process_dataset(df_labeled, "labeled", True) 
+    stats["artificial"] = process_dataset(df_artificial, "artificial", True)
+    
+    unique_records_list = list(unique_records.values())
+    
+    print("Extraction Results:")
+    print(f"  - Unique records from unlabeled: {stats['unlabeled']}")
+    print(f"  - Unique records from labeled: {stats['labeled']}")
+    print(f"  - Unique records from artificial: {stats['artificial']}")
+    print(f"  - Total unique records: {len(unique_records_list)}")
+    print(f"  - Duplicates avoided: {stats['duplicates']}")
+    
+    return unique_records_list, stats
 
 
 def load_pubmed_data(jsonl_path: str, limit: int = None) -> List[Dict[str, Any]]:
@@ -12,10 +105,9 @@ def load_pubmed_data(jsonl_path: str, limit: int = None) -> List[Dict[str, Any]]
     
     print(f"Loading PubMed data from {jsonl_path}")
     if limit:
-        print(f"🔢 Limiting to {limit} records for testing")
-    
+        print(f"Limiting to {limit} records for testing")
+
     with open(jsonl_path, 'r', encoding='utf-8') as file:
-        # Count total lines for progress bar
         print("Counting total lines...")
         total_lines = sum(1 for _ in file)
         file.seek(0)
@@ -24,21 +116,19 @@ def load_pubmed_data(jsonl_path: str, limit: int = None) -> List[Dict[str, Any]]
         progress_bar = tqdm(total=max_records, desc="Loading records")
         
         for line_num, line in enumerate(file, 1):
-            # Stop if we reached the limit
             if limit and len(pubmed_data) >= limit:
                 print(f"Reached limit of {limit} records, stopping...")
                 break
                 
             try:
                 data = json.loads(line.strip())
-                # Extract only the fields we need
                 if all(key in data.get('metadata', {}) for key in ['question', 'final_decision']) and \
                    'content' in data and 'contexts' in data['content'] and \
                    'long_answer' in data['content']:
                     
                     extracted_data = {
                         'question': data['metadata']['question'],
-                        'contexts': data['content']['contexts'],  # This is the list of contexts
+                        'contexts': data['content']['contexts'],
                         'final_decision': data['metadata']['final_decision'],
                         'long_answer': data['content']['long_answer']
                     }
@@ -67,49 +157,28 @@ def format_pubmed_for_embedding(
     pubmed_records: List[Dict[str, Any]], 
     max_length: int = 7000
 ) -> List[str]:
-    """Format PubMed records for embedding generation with length limits."""
+    """Format PubMed records for embedding generation - using ONLY context text."""
     formatted_texts = []
-    truncated_contexts = 0
-    truncated_answers = 0
     truncated_final = 0
     
-    print("Formatting texts for embedding...")
+    print("Formatting context texts for embedding...")
     
     for record in tqdm(pubmed_records, desc="Formatting records"):
-        # Combine contexts into a single text
+        # Use ONLY the contexts for embedding (RAG retrieval)
         contexts_text = " ".join(record['contexts'])
         
         # Truncate very long contexts to prevent token limit issues
-        if len(contexts_text) > 4000:
-            contexts_text = contexts_text[:4000] + "..."
-            truncated_contexts += 1
-        
-        # Truncate very long answers
-        long_answer = record['long_answer']
-        if len(long_answer) > 2000:
-            long_answer = long_answer[:2000] + "..."
-            truncated_answers += 1
-        
-        # Create comprehensive text for embedding
-        formatted_text = (
-            f"Question: {record['question']} "
-            f"Context: {contexts_text} "
-            f"Answer: {record['final_decision']} "
-            f"Explanation: {long_answer}"
-        )
-        
-        # Final length check and truncation
-        if len(formatted_text) > max_length:
-            formatted_text = formatted_text[:max_length] + "..."
+        if len(contexts_text) > max_length:
+            contexts_text = contexts_text[:max_length] + "..."
             truncated_final += 1
+        
+        # Use only context text for embedding
+        formatted_text = contexts_text
         
         formatted_texts.append(formatted_text)
     
-    # Print statistics
     print("Text formatting statistics:")
-    print(f"  - Truncated contexts: {truncated_contexts}")
-    print(f"  - Truncated answers: {truncated_answers}")
-    print(f"  - Truncated final texts: {truncated_final}")
+    print(f"  - Truncated contexts: {truncated_final}")
     print(f"  - Average text length: {sum(len(t) for t in formatted_texts) // len(formatted_texts)} chars")
     print(f"  - Max text length: {max(len(t) for t in formatted_texts)} chars")
     


### PR DESCRIPTION
This PR implements comprehensive PubMedQA dataset integration into the MedMax RAG pipeline with significant performance optimizations. The implementation introduces a context-only ingestion strategy that dramatically reduces storage requirements while maintaining retrieval quality by focusing on the essential medical context data rather than storing redundant question-answer pairs.

The integration processes all three PubMedQA dataset variants (unlabeled, labeled, and artificial) totaling 273,518 unique records through a unified parquet-based loader with automatic deduplication. The system combines multiple context passages per record into optimized embeddings while preserving critical metadata including publication IDs, decision labels, and source dataset information for comprehensive traceability.

How to Test
 - Data Ingestion: Run `scripts\01_populate_qdrant.bat --use-parquet --collection medmax_pubmed_full` to ingest the complete PubMedQA dataset with context optimization
 - Interactive Queries: Execute `scripts/02_rag_query.bat` and select interactive mode to test RAG retrieval against the new comprehensive collection
 - Single Query Testing: Use `scripts/02_rag_query.bat` with single query mode to verify response quality and source attribution from PubMedQA contexts
 - Collection Verification: Run query engine with --verbose flag to inspect retrieved contexts and confirm proper metadata preservation including publication IDs and decision labels
